### PR TITLE
Update add-basic-authentication-to-an-exposed-rest-api.md

### DIFF
--- a/src/extensibility-and-integration/rest/expose-rest-apis/add-basic-authentication-to-an-exposed-rest-api.md
+++ b/src/extensibility-and-integration/rest/expose-rest-apis/add-basic-authentication-to-an-exposed-rest-api.md
@@ -7,15 +7,23 @@ tags:
 
 ## Basic Authentication
 
-Basic authentication is a simple authentication scheme built into the HTTP protocol. The client sends HTTP requests with the **Authorization** header that contains the word **Basic** followed by a space and a base64-encoded string username:password. For example, to authorize user demo with password p@55w0rd the client would send:
+Basic authentication is a simple authentication scheme built into the HTTP protocol. The client sends HTTP requests with the "Authorization" header containing the word "Basic", a space character, and a "username:password" string encoded in Base64.
 
->Authorization: Basic ZGVtbzpwQDU1dzByZA==
+For example, to authorize the user "demo" with password "p@55w0rd" the client sends:
 
->**Note:** Because base64 is easily decoded, Basic authentication should only be used together with other security mechanisms such as **HTTPS/SSL**.
+    Authorization: Basic ZGVtbzpwQDU1dzByZA==
+    
+In this example, the `ZGVtbzpwQDU1dzByZA==` string results from encoding the string `demo:p@55w0rd` in Base64.
 
-If you want to know more about HTTP authentication, the [MDN Web Docs on HTTP authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication) is a good place to start.
+<div class="warning" markdown="1">
 
-## OutSystems Basic Authentication on REST API
+**Note:** Because Base64 is easily decoded, basic authentication should only be used together with other security mechanisms such as **HTTPS/SSL**.
+
+</div>
+
+To learn more about HTTP authentication, check for example the MDN Web Docs on [HTTP authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication).
+
+## Basic Authentication in OutSystems REST APIs
 
 OutSystems allows you to add basic authentication to the requests made to the REST APIs you are exposing.
 
@@ -29,11 +37,11 @@ For that, do the following:
 
 As a result, OutSystems creates the "OnAuthentication" action in your REST API to handle basic authentication with:
 
-* "Username" and "Password" input parameters holding the credentials passed in the request. This is automatically decoded from the Authorization HTTP header.
+* The "Username" and "Password" input parameters holding the credentials passed in the request (they are automatically decoded from the "Authorization" HTTP header)
 * The "User_Login" action to validate the credentials and identify the user
 
 ![](images/ss-rest-onauthentication-basic-flow.png)
 
 All methods in the REST API will now require Basic Authentication. User credentials are managed in your end user management application (by default, the [Users application](../../../develop/security/end-user-manage/accessing-users.md)).
 
-On the above example, the user is logged in and a session is created for the durations of the request. The GetUserID() method will return the user id and the CheckRole methods will also work, allowing you to create logic based on the user and his roles.
+In the example above, OutSystems logs in the user and creates a session for the duration of the request. The GetUserId() function returns the user ID and you can call the CheckRole built-in functions, allowing you to create logic based on the user and the roles assigned to the user.

--- a/src/extensibility-and-integration/rest/expose-rest-apis/add-basic-authentication-to-an-exposed-rest-api.md
+++ b/src/extensibility-and-integration/rest/expose-rest-apis/add-basic-authentication-to-an-exposed-rest-api.md
@@ -5,6 +5,18 @@ tags:
 
 # Add Basic Authentication to an Exposed REST API
 
+## Basic Authentication
+
+Basic authentication is a simple authentication scheme built into the HTTP protocol. The client sends HTTP requests with the **Authorization** header that contains the word **Basic** followed by a space and a base64-encoded string username:password. For example, to authorize user demo with password p@55w0rd the client would send:
+
+>Authorization: Basic ZGVtbzpwQDU1dzByZA==
+
+>**Note:** Because base64 is easily decoded, Basic authentication should only be used together with other security mechanisms such as **HTTPS/SSL**.
+
+If you want to know more about HTTP authentication, the [MDN Web Docs on HTTP authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication) is a good place to start.
+
+## OutSystems Basic Authentication on REST API
+
 OutSystems allows you to add basic authentication to the requests made to the REST APIs you are exposing.
 
 For that, do the following:
@@ -17,9 +29,11 @@ For that, do the following:
 
 As a result, OutSystems creates the "OnAuthentication" action in your REST API to handle basic authentication with:
 
-* "Username" and "Password" input parameters holding the credentials passed in the request
+* "Username" and "Password" input parameters holding the credentials passed in the request. This is automatically decoded from the Authorization HTTP header.
 * The "User_Login" action to validate the credentials and identify the user
 
 ![](images/ss-rest-onauthentication-basic-flow.png)
 
 All methods in the REST API will now require Basic Authentication. User credentials are managed in your end user management application (by default, the [Users application](../../../develop/security/end-user-manage/accessing-users.md)).
+
+On the above example, the user is logged in and a session is created for the durations of the request. The GetUserID() method will return the user id and the CheckRole methods will also work, allowing you to create logic based on the user and his roles.


### PR DESCRIPTION
Added generic description about basic authentication.
Explained that the user name and password are automatically read from the authorization header
Explicitly called out that the login creates a session and the getuserid() and checkrole methods are available