### PR TITLE
Customize REST url - mandatory input parameters

### DIFF
--- a/src/extensibility-and-integration/rest/expose-rest-apis/customize-rest-urls.md
+++ b/src/extensibility-and-integration/rest/expose-rest-apis/customize-rest-urls.md
@@ -16,10 +16,10 @@ to the following one:
 
 For that, do the following:
 
-1. In the **Logic** tab, open the **Integrations** folder. 
-1. Expand the REST API and select the method you want to change to display its properties. 
-1. Set the "URL Path" property of the REST API method to the new custom URL.  
-    Example: `/Contacts/{Id}`. 
+1. In the **Logic** tab, open the **Integrations** folder; 
+1. Expand the REST API and select the method you want to change to display its properties; 
+1. Set the "URL Path" property of the REST API method to the new custom URL;
+    1. Example: `/Contacts/{Id}` (input parameters must be set as mandatory). 
 
 The URL property will change accordingly.
 

--- a/src/extensibility-and-integration/rest/expose-rest-apis/customize-rest-urls.md
+++ b/src/extensibility-and-integration/rest/expose-rest-apis/customize-rest-urls.md
@@ -16,10 +16,13 @@ to the following one:
 
 For that, do the following:
 
-1. In the **Logic** tab, open the **Integrations** folder; 
-1. Expand the REST API and select the method you want to change to display its properties; 
-1. Set the "URL Path" property of the REST API method to the new custom URL;
-    1. Example: `/Contacts/{Id}` (input parameters must be set as mandatory). 
+1. In the **Logic** tab, open the **Integrations** folder. 
+1. Expand the REST API and select the method you want to change to display its properties. 
+1. Set the "URL Path" property of the REST API method to the new custom URL.
+
+    Example: `/Contacts/{Id}`
+
+    Note: Any input parameters included in the URL must be set as mandatory.
 
 The URL property will change accordingly.
 


### PR DESCRIPTION
Added note to explain that to customize an url path of an exposed REST the input parameters must be set as mandatory or it won't work (based on my investigation).