### PR TITLE
Update Multilingual top-level doc title

### DIFF
--- a/src/develop/ui/multilingual/intro.md
+++ b/src/develop/ui/multilingual/intro.md
@@ -3,7 +3,7 @@ summary: Learn how to create multilingual applications with OutSystems.
 tags: support-application_development; runtime-traditionalweb;
 ---
 
-# Multilingual UI
+# Translating Applications
 
 The UI of an application is designed for a particular language. This is called the default language, and it is in this language that the application is executed by default. You may have your application translated and executed in other languages, making it a multilingual application with a multilingual UI.
 

--- a/src/develop/ui/multilingual/intro.md
+++ b/src/develop/ui/multilingual/intro.md
@@ -3,7 +3,7 @@ summary: Learn how to create multilingual applications with OutSystems.
 tags: support-application_development; runtime-traditionalweb;
 ---
 
-# Translating Applications
+# Translating the app UI
 
 The UI of an application is designed for a particular language. This is called the default language, and it is in this language that the application is executed by default. You may have your application translated and executed in other languages, making it a multilingual application with a multilingual UI.
 


### PR DESCRIPTION
I am proposing that at least this top-level doc (“Multilingual UI”) is titled more explicitly to match what the users want to accomplish. E.g: “Translating Applications”. This would possibly help with improving this page SEO score.