### PR TITLE
Remove "iOS" from the title

### DIFF
--- a/src/develop/troubleshoot/inspect-http-requests-mobile.md
+++ b/src/develop/troubleshoot/inspect-http-requests-mobile.md
@@ -3,7 +3,7 @@ summary: Learn how to inspect the HTTP requests for mobile apps built for iOS.
 tags: support-application_development; support-Application_Troubleshooting; support-Mobile_Apps; runtime-mobile;
 ---
 
-# Inspect the HTTP requests in Mobile Apps for iOS
+# Inspect the HTTP requests in Mobile Apps
 
 
 Use the network inspector to see the network activity of your app. The user interface of the network inspector consists of a toolbar and a button that opens the screen with the network traffic details. 


### PR DESCRIPTION
Since this article talks about the network inspector for both iOS and Android, it does not make sense to include "iOS" in the title.