### PR TITLE
Update database-indexes.md

### DIFF
--- a/src/ref/data/database/database-indexes.md
+++ b/src/ref/data/database/database-indexes.md
@@ -8,7 +8,7 @@ When defining your entities, you can specify indexes, in addition to the ones au
 
 ## Automatic indexes
 
-For each foreign key you create with its delete rule set to Protect or Delete, OutSystems automatically creates an index. On the database, this index is prefixed with `OSIDX`.
+For each foreign key you create with its delete rule set to Protect or Delete, OutSystems automatically creates an index. In the database, this index is prefixed with `OSIDX`.
 
 `CREATE INDEX OSIDX_<internal name> ON <Entity>(<reference attribute>)`
 
@@ -16,7 +16,7 @@ Automatic indexes are deleted if the attribute Delete Rule is changed to Ignore.
 
 ## Custom Indexes
 
-You can define your own [indexes](<../../../develop/data/modeling/index-create.md>) on Service Studio to improve the performance of your applications. When you create an index, OutSystems creates it on the database with the `OSIDX` prefix.
+You can define [custom indexes](<../../../develop/data/modeling/index-create.md>) in Service Studio to improve the performance of your apps. When you create an index, OutSystems creates it in the database with the `OSIDX` prefix.
 
 ### Unique index
 
@@ -30,6 +30,6 @@ If you are using an Oracle database, you can define the Indexes tablespace in th
 
 <div class="warning" markdown="1">
 
-All the indexes that start with OSIDX_ are managed by the platform and shouldn’t be created or changed manually. Any change to these indexes outside the Platform mechanisms will be lost and have impact in the Platform behavior.
+The platform manages all indexes starting with `OSIDX_`. You shouldn't create or edit such indexes, as any custom change is discarded and impacts the correct functioning of the platform.
 
 </div>

--- a/src/ref/data/database/database-indexes.md
+++ b/src/ref/data/database/database-indexes.md
@@ -16,7 +16,7 @@ Automatic indexes are deleted if the attribute Delete Rule is changed to Ignore.
 
 ## Custom Indexes
 
-You can define your own [indexes](<../../../develop/data/modeling/index-create.md>), improve the performance of your applications. When you create an index, OutSystems creates it on the database with the `OSIDX` prefix.
+You can define your own [indexes](<../../../develop/data/modeling/index-create.md>) on Service Studio to improve the performance of your applications. When you create an index, OutSystems creates it on the database with the `OSIDX` prefix.
 
 ### Unique index
 
@@ -27,3 +27,9 @@ You can define your own [indexes](<../../../develop/data/modeling/index-create.m
 `CREATE INDEX OSIDX_<internal name> ON <Entity>(<attributes>)`
 
 If you are using an Oracle database, you can define the Indexes tablespace in the Configuration Tool.
+
+<div class="warning" markdown="1">
+
+All the indexes that start with OSIDX_ are managed by the platform and shouldn’t be created or changed manually. Any change to these indexes outside the Platform mechanisms will be lost and have impact in the Platform behavior.
+
+</div>

--- a/src/ref/data/database/database-indexes.md
+++ b/src/ref/data/database/database-indexes.md
@@ -1,35 +1,34 @@
 ---
+summary: Information for database administrators about database indexes. A preferred way of creating a database index is through Service Studio. You can also create them through SQL, but note that the OSIDX is a reserved prefix for the managed indexes.
 tags: support-Database
 ---
 
 # Database Indexes
 
-When defining your entities, you can specify indexes, in addition to the ones automatically created by OutSystems.
-
-## Automatic indexes
-
-For each foreign key you create with its delete rule set to Protect or Delete, OutSystems automatically creates an index. In the database, this index is prefixed with `OSIDX`.
-
-`CREATE INDEX OSIDX_<internal name> ON <Entity>(<reference attribute>)`
-
-Automatic indexes are deleted if the attribute Delete Rule is changed to Ignore.
-
-## Custom Indexes
-
-You can define [custom indexes](<../../../develop/data/modeling/index-create.md>) in Service Studio to improve the performance of your apps. When you create an index, OutSystems creates it in the database with the `OSIDX` prefix.
-
-### Unique index
-
-`CREATE UNIQUE INDEX OSIDX_<internal name> ON <Entity>(<attributes>)`
-
-### Not Unique index
-
-`CREATE INDEX OSIDX_<internal name> ON <Entity>(<attributes>)`
-
-If you are using an Oracle database, you can define the Indexes tablespace in the Configuration Tool.
+When a developer creates a foreign key in Service Studio, with the delete rule set to **Protect** or **Delete**, the platform automatically creates an index. In the database, this index has the `OSIDX` prefix. The platform deletes the automatically created indexes when you set **Delete Rule** to **Ignore**.
 
 <div class="warning" markdown="1">
 
-The platform manages all indexes starting with `OSIDX_`. You shouldn't create or edit such indexes, as any custom change is discarded and impacts the correct functioning of the platform.
+The platform manages all indexes starting with `OSIDX_`. You shouldn't create or edit indexes starting with `OSIDX_`, as any custom changes are discarded. Additionally, you may impact the correct functioning of the apps.
 
 </div>
+
+## Create indexes in Service Studio
+
+Developers can define custom indexes in Service Studio to improve the performance of the apps. Creating new indexes in Service Studio is the preferred way of creating database indexes.
+
+<div class="info" markdown="1">
+
+Seen [Create an Entity Index](<../../../develop/data/modeling/index-create.md>) for instructions about creating indexes in Service Studio.
+
+</div>
+
+## Create indexes through SQL
+
+If you're creating indexes through SQL interface, make sure you **give them a custom prefix**. Here are some examples of queries.
+
+`CREATE UNIQUE INDEX MYINDEX_<internal name> ON <Entity>(<attributes>)`
+
+`CREATE INDEX MYINDEX_<internal name> ON <Entity>(<attributes>)`
+
+Note: If you are using an Oracle database, you can define the Indexes tablespace in the **Configuration Tool**.


### PR DESCRIPTION
Changes to the database index document to make clear that the indexes need to be created in service studio and that the users should create or update any OSIDX index manually.