### PR TITLE
Update watches.md

### DIFF
--- a/src/develop/troubleshoot/debug/watches.md
+++ b/src/develop/troubleshoot/debug/watches.md
@@ -4,7 +4,6 @@ summary: Use watches to examine module elements while debugging threads in your 
 
 # Watches
 
-For the option "Add To Debug Watches" to become available, first execute the module in Debug mode. After that, right click on the element of the module or in other module and the option will be available in the Watch tab.
 Watches allow you to examine module elements in Service Studio while debugging your module. These elements are always displayed in the Watches Tab, regardless of being in or out of scope of the element being debugged. This behavior contrasts with the rest of the [scope tabs](<debugger-ui-reference.md#scope-tabs-area>), where the displayed content depends on the current scope.
 
 Using watches you can inspect:
@@ -18,10 +17,11 @@ Using watches you can inspect:
 
 To watch a module element do the following:
 
-1. Right-click on the element to watch, either in the Scope tabs or in the module tree.
+1. Run the module in Debug mode.
+1. Right-click the element to watch, either in the Scope tabs or in the module tree.
 1. Select the "Add To Debug Watches" option in the pop-up menu. 
 
-All watched module elements are alphabetically listed in the Watches Tab.
+All watched module elements are alphabetically listed in the Watches Tab. 
 
 
 ## Remove a Watch

--- a/src/develop/troubleshoot/debug/watches.md
+++ b/src/develop/troubleshoot/debug/watches.md
@@ -4,6 +4,7 @@ summary: Use watches to examine module elements while debugging threads in your 
 
 # Watches
 
+For the option "Add To Debug Watches" to become available, first execute the module in Debug mode. After that, right click on the element of the module or in other module and the option will be available in the Watch tab.
 Watches allow you to examine module elements in Service Studio while debugging your module. These elements are always displayed in the Watches Tab, regardless of being in or out of scope of the element being debugged. This behavior contrasts with the rest of the [scope tabs](<debugger-ui-reference.md#scope-tabs-area>), where the displayed content depends on the current scope.
 
 Using watches you can inspect:


### PR DESCRIPTION
This info is missing in this page
For the option "Add To Debug Watches" to become available, first execute the module in Debug mode. After that, right click on the element of the module or in other module and the option will be available in the Watch tab.