### PR TITLE
#RTAF-3424 - Update PWA documentation regarding an issue found in PS 11.9.0

### DIFF
--- a/src/deliver-mobile/distribute-pwa/intro.md
+++ b/src/deliver-mobile/distribute-pwa/intro.md
@@ -60,6 +60,13 @@ Mobile best practices apply for PWA development as well, particularly about [des
 
 </div>
 
+<div class="warning" markdown="1">
+
+OutSystems identified an issue in Platform Server 11.9.0 where the stage of the value of the PWA toggle in LifeTime is not working as expected. If you wish to keep the distribution as PWA enabled/disabled in the target environment you should enable/disable the toggle in the target environment manually as the stage will not keep the value of the toggle from the source environment.
+This issue will be fixed for Platform Server 11.10.0.
+
+</div>
+
 ## Run the PWA
 
 Here is how you can run your PWA. Go to the app details in Service Studio and click **Distribute** tab:

--- a/src/deliver-mobile/distribute-pwa/intro.md
+++ b/src/deliver-mobile/distribute-pwa/intro.md
@@ -60,13 +60,6 @@ Mobile best practices apply for PWA development as well, particularly about [des
 
 </div>
 
-<div class="warning" markdown="1">
-
-OutSystems identified an issue in Platform Server 11.9.0 where the stage of the value of the PWA toggle in LifeTime is not working as expected. If you wish to keep the distribution as PWA enabled/disabled in the target environment you should enable/disable the toggle in the target environment manually as the stage will not keep the value of the toggle from the source environment.
-This issue will be fixed for Platform Server 11.10.0.
-
-</div>
-
 ## Run the PWA
 
 Here is how you can run your PWA. Go to the app details in Service Studio and click **Distribute** tab:
@@ -138,12 +131,6 @@ Service Studio generates the manifest automatically. Modify the manifest only if
 (*) Service Studio generates the four required resolutions of the icon.
 
 ### Override the manifest settings {#override-pwa-manifest}
-
-<div class="warning" markdown="1">
-
-OutSystems identified an issue that prevents LifeTime from overriding the PWA Extensibility Configurations. The development team is working on the fix. Note that you can still use Extensibility Configurations in Service Studio.
-
-</div>
 
 <div class="info" markdown="1">
 
@@ -259,3 +246,15 @@ Here are some suggestions to fix the issue:
 ### There are runtime errors
 
 Try deleting the local data of the app. Locate the settings in the browser, and clear the data for the app installation domain. In Chrome, go to **Settings** > **Site Settings** > **Cookies and site data** > **See all cookies and site data**, search for the domain and clear the data.
+
+## Known issues
+
+Here are the current known issues with PWA.
+
+### Overriding the Extensibility Configurations in LifeTime isn't working
+
+There's an issue that prevents LifeTime from overriding the PWA Extensibility Configurations. The development team is working on the fix. Note that you can still use Extensibility Configurations in Service Studio.
+
+### Staging of the PWA toggle value in LifeTime isn't working
+
+In Platform Server 11.9.0, the staging of the PWA toggle value in LifeTime isn't working as expected. To keep the PWA distribution settigs in the target environment, set the toggle in the target environment manually. OutSystems is working on a fix.


### PR DESCRIPTION
In Platform Server 11.9.0 an issue was found in the stage of the PWA toggle value. It was added as a known issue to the release notes page of that Platform Version page: https://success.outsystems.com/Support/Release_Notes/11/Platform_Server/Platform_Server_11.9.0

When staging an application, the value of the toggle should be staged from the source to the target environment. So if an application has the PWA toggle enabled, when staging that app the target environment should also have the PWA toggle enabled (and vice versa, if the toggle was disabled in the source should be disabled after staging it to the target environment).

A fix for this problem was included in the next Platform Server release, 11.10.0.