### PR TITLE
#RTAF-3434 - Update version where issue for App Feedback in Reactive will be fixed

### DIFF
--- a/src/managing-the-applications-lifecycle/app-feedback/user-feedback-enable.md
+++ b/src/managing-the-applications-lifecycle/app-feedback/user-feedback-enable.md
@@ -28,7 +28,7 @@ You can deactivate user feedback for an app the same way, this time turning the 
 
 <div class="warning" markdown="1">
 
-OutSystems has identified a temporary limitation in managing App Feedback. Once you turn on App Feedback in a Reactive Web App, you can't turn it off. The team behind the feature is working on a fix.
+OutSystems has identified a temporary limitation in managing App Feedback. Once you turn on App Feedback in a Reactive Web App, you can't turn it off. The fix will be available in Platform Server 11.10.0.
 
 </div>
 

--- a/src/managing-the-applications-lifecycle/app-feedback/user-feedback-enable.md
+++ b/src/managing-the-applications-lifecycle/app-feedback/user-feedback-enable.md
@@ -26,11 +26,6 @@ Use the App Feedback system app to configure the user feedback feature. You can 
 
 You can deactivate user feedback for an app the same way, this time turning the feedback switch off. Again. If you're deactivating user feedback for a **mobile app**, you must **regenerate the app to remove the feedback feature**.
 
-<div class="warning" markdown="1">
-
-OutSystems has identified a temporary limitation in managing App Feedback. Once you turn on App Feedback in a Reactive Web App, you can't turn it off. The fix will be available in Platform Server 11.10.0.
-
-</div>
 
 ## Restrict who can submit feedback
 


### PR DESCRIPTION
An issue was previously identified for App Feedback in Reactive applications: once App Feedback was enabled, it wasn't possible to disable it. This was documented in the App Feedback main documentation page but now that we have the fix ready for the next version we should update that note so that users know the fix is comming soon.