### PR TITLE
Number of Timers running in parallel

### DIFF
--- a/src/develop/timers/intro.md
+++ b/src/develop/timers/intro.md
@@ -10,7 +10,7 @@ You can use **Timers** to execute asynchronous logic in your OutSystems applicat
 
 Timers are handled by the OutSystems Scheduler Service. This service checks for Timers that are ready to run and executes their actions. A Timer is ready to run when the current time is greater or equal to the Timer runtime property `NextRun`.
 
-Since Timers usually invoke actions that take a while to run and are processor intensive, the OutSystems Scheduler Service only runs a fixed number of Timers at the same time. By default only 3 Timers can run at the same time per frontend server, but this number can be customized in the OutSystems Configuration Tool.
+Since Timers usually invoke actions that take a while to run and are processor intensive, the OutSystems Scheduler Service only runs a fixed number of Timers at the same time. By default only 3 Timers can run at the same time per front-end server, but this number can be customized in the OutSystems Configuration Tool.
 
 When more than 3 Timers are scheduled to run at the same time, the Timers with higher priority run first.
 
@@ -20,7 +20,7 @@ If a Timer is not executed, if an unhandled exception occurs, or if the action t
 
 <div class="info" markdown="1">
 
-For Timers to operate correctly, make sure that the environment's database, controller and all front-ends are in the [same timezone and their system clocks are synchronized](https://success.outsystems.com/Support/Enterprise_Customers/Maintenance_and_Operations/Timezone_considerations_in_the_OutSystems_Platform).
+For Timers to operate correctly, make sure that the environment's database, controller and all front-end servers are in the [same timezone and their system clocks are synchronized](https://success.outsystems.com/Support/Enterprise_Customers/Maintenance_and_Operations/Timezone_considerations_in_the_OutSystems_Platform).
 
 </div>
 

--- a/src/develop/timers/intro.md
+++ b/src/develop/timers/intro.md
@@ -10,7 +10,7 @@ You can use **Timers** to execute asynchronous logic in your OutSystems applicat
 
 Timers are handled by the OutSystems Scheduler Service. This service checks for Timers that are ready to run and executes their actions. A Timer is ready to run when the current time is greater or equal to the Timer runtime property `NextRun`.
 
-Since Timers usually invoke actions that take a while to run and are processor intensive, the OutSystems Scheduler Service only runs a fixed number of Timers at the same time. By default only 3 Timers can run at the same time, but this number can be customized in the OutSystems Configuration Tool.
+Since Timers usually invoke actions that take a while to run and are processor intensive, the OutSystems Scheduler Service only runs a fixed number of Timers at the same time. By default only 3 Timers can run at the same time per frontend server, but this number can be customized in the OutSystems Configuration Tool.
 
 When more than 3 Timers are scheduled to run at the same time, the Timers with higher priority run first.
 


### PR DESCRIPTION
Updated line 13:
Before "By default only 3 Timers can run at the same time, (...)"
Now: "By default only 3 Timers can run at the same time per frontend server, (...)"

To make explicit the number of timers running in parallel.