### PR TITLE
Update known issue

### DIFF
--- a/src/deliver-mobile/distribute-pwa/intro.md
+++ b/src/deliver-mobile/distribute-pwa/intro.md
@@ -260,4 +260,4 @@ There's an issue that prevents LifeTime from overriding the PWA Extensibility Co
 
 ### Staging of the PWA toggle value in LifeTime isn't working
 
-In Platform Server 11.9.0, the staging of the PWA toggle value in LifeTime isn't working as expected. To keep the PWA distribution setting in the target environment, set the toggle in the target environment manually. OutSystems is working on a fix.
+In Platform Server 11.9.0, the staging of the PWA toggle value in LifeTime isn't working as expected. Upgrade to Platform Server 11.10.0 to resolve the issue.

--- a/src/deliver-mobile/distribute-pwa/intro.md
+++ b/src/deliver-mobile/distribute-pwa/intro.md
@@ -260,4 +260,4 @@ There's an issue that prevents LifeTime from overriding the PWA Extensibility Co
 
 ### Staging of the PWA toggle value in LifeTime isn't working
 
-In Platform Server 11.9.0, the staging of the PWA toggle value in LifeTime isn't working as expected. Upgrade to Platform Server 11.10.0 to resolve the issue.
+In Platform Server 11.9.0, the staging of the PWA toggle value in LifeTime isn't working as expected. Upgrade to Platform Server 11.10.0 or later to resolve the issue.


### PR DESCRIPTION
Following the release of Platform Server 11.10.0 that was released earlier this week, I've updated the known issue related to the PWA toggle not being staged in LifeTime.
I'm not exactly sure if we should remove this known issue all together but since the version just came out this week and the large bulk of our customers is still in previous versions I would like to keep if for a little longer, let me know what you think :)