### PR TITLE
RRCT-3142 Mobile Sessions behavior on log out

### DIFF
--- a/src/managing-the-applications-lifecycle/secure-the-applications/configure-authentication.md
+++ b/src/managing-the-applications-lifecycle/secure-the-applications/configure-authentication.md
@@ -101,8 +101,12 @@ The authentication mechanism for apps includes caching capabilities to avoid the
 
 Within a defined period of time the server uses the information stored in the cookies to authenticate the requests of an authenticated session, instead of retrieving the authentication information from the database.
 
-### Logging Out of Applications
+### Logging out of the application
 
-When the user logs out of an app, either in traditional web or in a mobile device, it also logs him out from all other sessions. It prevents invalid persistent authentication sessions from staying alive.
+When the end user logs out of an application, all sessions are terminated. This prevents any invalid persistent authenticated session from staying alive.
 
-If the application is configured to use Cache Time In Minutes, it may still work for a few time, until cache is invalidated and the authentication information must be fetched from the database, where it's no longer valid.
+<div class="info" markdown="1">
+
+If the application contains [elements with caching enabled](../../develop/data/caching.md) (using the Cache in Minutes property), the cached content might still be displayed for a small period of time, until the cache is invalidated. After that period, the authentication information must be fetched again from the database, as it's no longer valid.
+
+</div>

--- a/src/managing-the-applications-lifecycle/secure-the-applications/configure-authentication.md
+++ b/src/managing-the-applications-lifecycle/secure-the-applications/configure-authentication.md
@@ -100,3 +100,9 @@ If all conditions apply, the server authenticates the request as coming from the
 The authentication mechanism for apps includes caching capabilities to avoid the overhead of validating and updating authentication information in the database upon each request.
 
 Within a defined period of time the server uses the information stored in the cookies to authenticate the requests of an authenticated session, instead of retrieving the authentication information from the database.
+
+### Logging Out of Applications
+
+When the user logs out of an app, either in traditional web or in a mobile device, it also logs him out from all other sessions. It prevents invalid persistent authentication sessions from staying alive.
+
+If the application is configured to use Cache Time In Minutes, it may still work for a few time, until cache is invalidated and the authentication information must be fetched from the database, where it's no longer valid.


### PR DESCRIPTION
When an explicit logout occurs (either Web or Mobile) all Mobile sessions are terminated.
This behavior is often not expected by customers. To make things worse, the Cache In Minutes setting "hides" the logout which makes users/customers believe a "random" logout occurs at some point in time.
We should probably document this somewhere to avoid getting multiple support cases related without.