### PR TITLE
Adding gap: default values

### DIFF
--- a/src/managing-the-applications-lifecycle/secure-the-applications/apply-content-security-policy.md
+++ b/src/managing-the-applications-lifecycle/secure-the-applications/apply-content-security-policy.md
@@ -85,9 +85,9 @@ The list of available directives to configure Content Security Policy in OutSyst
 | Directive     | Reason        | Default values  |
 | :------------ |:--------------|:----------------|
 | Base-uri      |The domains which can be used as base URL for applications screens.<br/>The following source expressions are allowed: `self`.|`self`|
-| Child-src     |The domains which applications are allowed to embed framed.<br/>The following source expressions are allowed: `self` and `*`.|`self`|
+| Child-src     |The domains which applications are allowed to embed framed.<br/>The following source expressions are allowed: `self` and `*`.|`self`<br/>`gap:`|
 | Connect-src   |The domains from which applications are allowed to load resources using script interfaces.<br/>The following source expressions are allowed: `self` and `*`.|`self`|
-| Default-src   |The domains from which applications are allowed to load resources, by default.<br/>Any resource type dedicated directive (like object-src or img-src) that is not defined will inherit this configuration.<br/>The following source expressions are allowed: `self`, `data:` and `*`.|`self`|
+| Default-src   |The domains from which applications are allowed to load resources, by default.<br/>Any resource type dedicated directive (like object-src or img-src) that is not defined will inherit this configuration.<br/>The following source expressions are allowed: `self`, `data:` and `*`.|`self`<br/>`gap:`|
 | Font-src      |The domains from which applications are allowed to load fonts.<br/>The following source expressions are allowed: `self`, `data:` and `*`.|`self`<br/>`data:`|
 | Img-src       |The domains from which applications are allowed to load images.<br/>The following source expressions are allowed: `self`, `data:` and `*`.|`self`<br/>`data:`|
 | Media-src     |The domains from which applications are allowed to load media files.<br/>The following source expressions are allowed: `self`, `data:` and `*`.|-|
@@ -95,7 +95,7 @@ The list of available directives to configure Content Security Policy in OutSyst
 | Plugin-types  |The valid plugins that the user browser may invoke|-|
 | Script-src    |The domains from which applications are allowed to load scripts.<br/>The following source expressions are allowed: `self`, `data:` and `*`.|`self`|
 | Style-src     |The domains from which applications are allowed to load styles.<br/>The following source expressions are allowed: `self`, `data:` and `*`.|`self`|
-| Frame-ancestors|The domains which are allowed to embed applications in a frame.<br/>The following source expressions are allowed: `self` and `*`.|`self`|
+| Frame-ancestors|The domains which are allowed to embed applications in a frame.<br/>The following source expressions are allowed: `self` and `*`.|`self`<br/>`gap:`|
 | Report-to     |URI where content security violations will be reported.|`<internal>`|
 | Other directives|More directives to append to the Content Security Policy headers.|-|
 


### PR DESCRIPTION
Just checked in a newly created sandbox environment and noticed that the values above were missing in our docs.