### PR TITLE
Fixed Configuration Tool command line reference for installing system components

### DIFF
--- a/src/setup/unattended-install/config-tool-ref.md
+++ b/src/setup/unattended-install/config-tool-ref.md
@@ -29,8 +29,7 @@ ConfigurationTool.com
     | /UpgradeInstall [<integrated_auth_admin_password>] [/SetPlatformServerAdminPassword <platform_server_admin_password>] 
     | /RebuildSession <session_db_admin_username> <session_db_admin_password> 
     | /SCInstall 
-    | /UpgradeSystemComponents
-    | /UpgradePublishedApplications
+    | /InstallSystemComponents
     | /GenerateTemplates
     | /ClearInternalNetwork
     | /UploadLicense <license_file> <platform_server_admin_user> <platform_server_admin_password>
@@ -74,13 +73,9 @@ ConfigurationTool.com
 
 :   Forces the Service Center installation to run after finishing Configuration Tool.
 
-`/UpgradeSystemComponents`
+`/InstallSystemComponents`
 
 :   Forces the System Components installation or upgrade to run after applying the configuration settings.
-
-`/UpgradePublishedApplications`
-
-:   Forces the published applications upgrade to run after applying the configuration settings.
 
 `/GenerateTemplates`
 
@@ -138,7 +133,7 @@ ConfigurationTool.com
 
 `/UpgradeEnvironment`
 
-:   Installs Service Center and System Components, and upgrades published applications. Skips any of these steps if they were previously executed.
+:   Installs Service Center and System Components. Skips any of these steps if they were previously executed.
 
 `/ApplySettingsFactory`
 


### PR DESCRIPTION
Fixed Configuration Tool switch for installing system components and removed unreleased switch.

Issue: the actual switch available since 11.9+ is /InstallSystemComponents and the documentation doesn't reflect that.