### PR TITLE
RTAF-4156 - Confirmation Message for a Link to a Popup

### DIFF
--- a/src/develop/ui/inputs/popup.md
+++ b/src/develop/ui/inputs/popup.md
@@ -111,11 +111,14 @@ Here is a [video tutorial about using Popup in Traditional Web App](https://www.
 
 ### Notes
 
-#### How to display a Confirmation Message for a Link that navigates to a Popup
-When a Link widget has a Confirmation Message and the destination a RichWidgets\Popup_Upload, the Confirmation Message is never displayed. If you want to achieve that experience, you'll need to first navigate to a hidden Link that can then navigate to a RichWidgets\Popup_Upload:
+Here are some additional notes about the Popup widget.
 
-1. Add a Link widget with the property **Confirmation Message** filled.
+#### Showing a Confirmation Message for a Link that navigates to a Popup
 
-1. Set its **Destination** as a **Server Action** that uses **RichWidgets\Widget_Click** action to select the **id** of a second Link widget.
+When a Link widget has a Confirmation Message with the destination **RichWidgets\Popup_Upload**, the app doesn't show the Confirmation Message. To show the message, first navigate to a hidden Link that can then navigate to a RichWidgets\Popup_Upload:
 
-1. Set the second Link's **Visibility** property as **False** and its **Destination** as **RichWidgets\Popup_Upload**.
+1. Add a **Link** widget and enter the message in the property **Confirmation Message**.
+
+1. Set the Link **Destination** to **Server Action** that uses **RichWidgets\Widget_Click** and select the **id** of the second Link widget.
+
+1. Set the second Link **Visibility** property as **False** and its **Destination** as **RichWidgets\Popup_Upload**.

--- a/src/develop/ui/inputs/popup.md
+++ b/src/develop/ui/inputs/popup.md
@@ -108,3 +108,14 @@ After following these steps and publishing the module, you can test the pattern 
 Here is a [video tutorial about using Popup in Traditional Web App](https://www.youtube.com/watch?v=ShOCxc3g91M).
 
 </div>
+
+### Notes
+
+#### How to display a Confirmation Message for a Link that navigates to a Popup
+When a Link widget has a Confirmation Message and the destination a RichWidgets\Popup_Upload, the Confirmation Message is never displayed. If you want to achieve that experience, you'll need to first navigate to a hidden Link that can then navigate to a RichWidgets\Popup_Upload:
+
+1. Add a Link widget with the property **Confirmation Message** filled.
+
+1. Set its **Destination** as a **Server Action** that uses **RichWidgets\Widget_Click** action to select the **id** of a second Link widget.
+
+1. Set the second Link's **Visibility** property as **False** and its **Destination** as **RichWidgets\Popup_Upload**.


### PR DESCRIPTION
When a Link widget has a Confirmation Message and the destination a RichWidgets\Popup_Upload, the Confirmation Message is never displayed. This change is a step-by-step explanation on how the user can still show a Link's Confirmation Message if the destination of the Link is a PopupUpload.