### PR TITLE
RTAF-3972:  Removing performance warning for OnReady

### DIFF
--- a/src/develop/logic/screen-block-lifecycle-events.md
+++ b/src/develop/logic/screen-block-lifecycle-events.md
@@ -108,7 +108,7 @@ The On Ready event handler runs when the Screen or Block is ready, i.e. when the
 Notes:
 
 * The DOM of the previous and current Screens are loaded when this event is triggered. To ensure that you are operating on the screen being created, execute logic only for the HTML `div` element with the class `active-screen`. 
-* Keep this event handler action simple and avoid slow actions such as server requests, since it may delay the render of the Screen or Block. 
+* Keep this event handler action simple and avoid using Screen Aggregates or Data Actions, which run in parallel, to manipulate data that might not be available.
 * Avoid accessing the data of the Screen or Block since this action runs before the data is fetched. If you need to develop some logic on these data, use the On After Fetch event handler of the respective Aggregate or Data Action. 
 
 Use cases you can implement with this event handler:

--- a/src/ref/errors-and-warnings/warnings/performance-suggestion-warning.md
+++ b/src/ref/errors-and-warnings/warnings/performance-suggestion-warning.md
@@ -42,13 +42,13 @@ Recommendation
 <a id="helpid-30140"></a>
 
 Message
-:   `'<OnInitialize action | OnReady action>' contains accesses to the local storage or server, which delays the screen's render. To avoid performance issues, use Aggregates or Data Actions instead.`
+:   `'<OnInitialize action>' contains accesses to the local storage or server, which delays the screen's render. To avoid performance issues, use Aggregates or Data Actions instead.`
 
 Cause
-:   The rendering of the screen only starts after the OnInitialize and the OnReady actions finish. If you access to the local storage or execute requests to the server during this stage, you may delay the rendering of the screen and make the app look unresponsive.
+:   The rendering of the screen only starts after the OnInitialize action finishes. If you access the local storage or execute requests to the server during this stage, you may delay the rendering of the screen and make the app look unresponsive.
 
 Recommendation
-:   Move all the accesses to local storage or server into screen Aggregates or Data Actions. This way the render starts sooner and the fetching for data or other server operations will run concurrently while the screen is rendering. For more information, see the [Screen and Block Lifecycle Events](<../../../develop/logic/screen-block-lifecycle-events.md>) documentation.
+:   Move all logic that accesses local storage or server into screen Aggregates or Data Actions. This way the rendering starts sooner and the fetching of the data or other server operations runs concurrently, while the screen is rendering. For more information, see the [Screen and Block Lifecycle Events](<../../../develop/logic/screen-block-lifecycle-events.md>) documentation.
 
 ---
 

--- a/src/ref/errors-and-warnings/warnings/performance-suggestion-warning.md
+++ b/src/ref/errors-and-warnings/warnings/performance-suggestion-warning.md
@@ -41,27 +41,16 @@ Recommendation
 
 <a id="helpid-30140"></a>
 
-Message
-:   `'<OnInitialize action>' contains accesses to the local storage or server, which delays the screen's render. To avoid performance issues, use Aggregates or Data Actions instead.`
-
-Cause
-:   The rendering of the screen only starts after the OnInitialize action finishes. If you access the local storage or execute requests to the server during this stage, you may delay the rendering of the screen and make the app look unresponsive.
-
-Recommendation
-:   Move all logic that accesses local storage or server into screen Aggregates or Data Actions. This way the rendering starts sooner and the fetching of the data or other server operations runs concurrently, while the screen is rendering. For more information, see the [Screen and Block Lifecycle Events](<../../../develop/logic/screen-block-lifecycle-events.md>) documentation.
-
----
-
 <a id="helpid-30141"></a>
 
 Message
-:   `'<OnInitialize action | OnReady action>' contains accesses to the local storage or server, which delays the block's render. To avoid performance issues, use Aggregates or Data Actions instead.`
+:   `'<OnInitialize action>' contains accesses to the local storage or server, which delays the <screen | block >'s render. To avoid performance issues, use Aggregates or Data Actions instead.`
 
 Cause
-:   Accessing the local storage or executing requests to the server in the OnInitialize or OnReady actions of a block may delay the render of the block.
+:   The rendering of the screen/block only starts after the OnInitialize action finishes. If you access the local storage or execute requests to the server during this stage, you may delay the rendering of the screen/block and make the app look unresponsive.
 
-Recommendations
-:   Move all accesses to the local storage or server into block Aggregates or Data Actions. For more information, see the [Screen and Block Lifecycle Events](<../../../develop/logic/screen-block-lifecycle-events.md>) documentation.
+Recommendation
+:   Move all logic that accesses local storage or server into Screen Aggregates or Data Actions. This way the rendering starts sooner and the fetching of the data or running other server operations runs concurrently, while the screen/block is rendering. For more information, see the [Screen and Block Lifecycle Events](<../../../develop/logic/screen-block-lifecycle-events.md>) documentation.
 
 ---
 


### PR DESCRIPTION
The performance warning about slow server calls was removed, as requested.  On recommendation by Tiago Simoes and Sandro Cantante, this text was replaced with a message to avoid screen aggregates and data actions in OnReady.