### PR TITLE
Log Message - Message input limited to 2000 chars

### DIFF
--- a/src/ref/apis/auto/system-actions.md
+++ b/src/ref/apis/auto/system-actions.md
@@ -710,7 +710,7 @@ Registers information that can be presented in Service Center in the module gene
 
 Message
 :   Type: mandatory, Text.  
-    The message to add to the module general log.
+    The message to add to the module general log. Limited to 2000 chars.
 
 ModuleName
 :   Type: mandatory, Text.  


### PR DESCRIPTION
Hi there! While developing and logging some needed info, I discovered that the message input parameter from the LogMessage server action is limited to 2000 chars (my log was truncated :( ). I didn't discover any platform configuration to increase this nr of chars. Please consider to include this information in the documentation and Service Studio. Cheers ape <3