### PR TITLE
Change Widget name from "Content" to "Text"

### DIFF
--- a/src/develop/ui/reuse/block-create-reuse.md
+++ b/src/develop/ui/reuse/block-create-reuse.md
@@ -29,7 +29,7 @@ Here is an example, with two sample apps, of how you can reuse a Block from Reac
 1. Create a new Reactive Web App, and add a default Module to it.
 1. In the Module, go to **Interface** > **UI Flows** > right-click **MainFlow** > select **Add Block**. Name the Block **MyBlock**.
 1. Set the **Public** property of Block to **Yes**.
-1. Add some content to the Block. In our example we dragged a Content Widget and entered sample text "Hello from My Reactive App!".
+1. Add some content to the Block. In our example we dragged a Text Widget and entered sample text "Hello from My Reactive App!".
 
     ![Source app with a public Block](<images/block-reuse-source-app.png?width=600>)
 


### PR DESCRIPTION
Content widget is not a widget of OS11. I have proposed "Text Widget".
OS11 Reactive Core Widgets
https://success.outsystems.com/Support/Enterprise_Customers/Upgrading/Introduction_to_migrating_Traditional_Web_to_Reactive_Web_Apps/Traditional_to_Reactive_App_migration_reference/Core_widgets?utm_source=service-studio&utm_medium=ost-outsystems-tools&searchId=0af0314c-a6c9-43bb-8ef1-63ada2f93afb#container