### PR TITLE
Warning for on-premises

### DIFF
--- a/src/managing-the-applications-lifecycle/secure-the-applications/apply-content-security-policy.md
+++ b/src/managing-the-applications-lifecycle/secure-the-applications/apply-content-security-policy.md
@@ -78,7 +78,7 @@ When configuring CSP take into account the following risks of misconfiguration:
 
 * **Too permissive policies**: Be especially cautious when allowing resources to be loaded from everywhere (by using `*` in the domain list). Hackers may take advantage of links, scripts, or other resources in your applications to redirect users to malicious pages.
 
-* **Duplicated configuration**: On on-premises environments, do not set the CSP outside the the OutSystems Platform (directly in the IIS, for example). This will cause unespected results, since the CSP directives will be included twice.
+* **Duplicated configuration**: On self-managed environments, set the CSP directives only in LifeTime. Don't set them directly in IIS, for example. This will cause unexpected results, since the CSP directives will be included twice.
 
 ## Directives reference
 

--- a/src/managing-the-applications-lifecycle/secure-the-applications/apply-content-security-policy.md
+++ b/src/managing-the-applications-lifecycle/secure-the-applications/apply-content-security-policy.md
@@ -78,7 +78,7 @@ When configuring CSP take into account the following risks of misconfiguration:
 
 * **Too permissive policies**: Be especially cautious when allowing resources to be loaded from everywhere (by using `*` in the domain list). Hackers may take advantage of links, scripts, or other resources in your applications to redirect users to malicious pages.
 
-* **Duplicated configuration**: On self-managed environments, set the CSP directives only in LifeTime. Don't set them directly in IIS, for example. This will cause unexpected results, since the CSP directives will be included twice.
+* **Duplicated configuration**: On self-managed environments, set the CSP directives only in LifeTime. Don't set them directly in IIS, for example. It will cause unexpected results, by including the CSP directives twice.
 
 ## Directives reference
 

--- a/src/managing-the-applications-lifecycle/secure-the-applications/apply-content-security-policy.md
+++ b/src/managing-the-applications-lifecycle/secure-the-applications/apply-content-security-policy.md
@@ -78,6 +78,8 @@ When configuring CSP take into account the following risks of misconfiguration:
 
 * **Too permissive policies**: Be especially cautious when allowing resources to be loaded from everywhere (by using `*` in the domain list). Hackers may take advantage of links, scripts, or other resources in your applications to redirect users to malicious pages.
 
+* **Duplicated configuration**: On on-premises environments, do not set the CSP outside the the OutSystems Platform (directly in the IIS, for example). This will cause unespected results, since the CSP directives will be included twice.
+
 ## Directives reference
 
 The list of available directives to configure Content Security Policy in OutSystems is described in the table below.


### PR DESCRIPTION
Added warning message to not set the CSP directives on other places besides Service Center/LifeTime.