### PR TITLE
Revert "Explain current language scope/duration"

### DIFF
--- a/src/develop/ui/multilingual/intro.md
+++ b/src/develop/ui/multilingual/intro.md
@@ -14,5 +14,3 @@ These instructions are for translating Traditional Web Apps only. For Reactive W
 The UI of an application is designed for a particular language. This is called the default language, and it is in this language that the application is executed by default. You may have your application translated and executed in other languages, making it a multilingual application with a multilingual UI.
 
 Use the OutSystems built-in mechanisms to [localize your Traditional Web Applications](multilingual-web.md) and learn more about the end-to-end Traditional Web Application localization process in this [Master Class on Multi-Language](https://www.outsystems.com/learn/lesson/1144/master-class-on-multi-language/). For mobile apps, use the [Multilingual Mobile Component](https://www.outsystems.com/forge/component/1784/multilingual-mobile-component) from Forge.
-
-The current language is bound to the user session. When the user logs out the language automatically changes to the default one (en-US).


### PR DESCRIPTION
Reverts OutSystems/docs-product#179

The info should go to the Multilingual tech preview. 