### PR TITLE
New parameter on section Create a Keystore

### DIFF
--- a/src/deliver-mobile/generate-distribute-mobile-app/more-information.md
+++ b/src/deliver-mobile/generate-distribute-mobile-app/more-information.md
@@ -144,7 +144,7 @@ To create a new keystore, you can use the [keytool](https://docs.oracle.com/java
 
 After you verify the availability of the keytool command, open a computer command prompt (Start > Run > `cmd.exe`) and, if the keytool command is not available in the path, navigate to the Java "bin" directory. Execute:
     
-    keytool -genkey -v -keystore <keystore_name>.keystore -alias <alias_name> -keyalg RSA -keysize 2048 -validity 10000
+    keytool -genkey -v -keystore <keystore_name>.keystore -alias <alias_name> -keyalg RSA -keysize 2048 -validity 10000 -storetype jks
 
 where:
 


### PR DESCRIPTION
As described here: https://stackoverflow.com/questions/49598701/keytool-do-not-ask-for-alias-password, more recent versions of Java's (both JDK and JRE) Keytool when running the command: keytool -genkey -v -keystore <keystore_name>.keystore -alias <alias_name> -keyalg RSA -keysize 2048 -validity 10000, creates a certificate with the type set to PKCS12. This type is not accepted by MABS, and when compiling a Releasing version of an App will throw the exception: Invalid keystore format.
By setting -storetype jks the certificate will generate as expected requesting both the certificate password and the alias password.