### PR TITLE
Updated last step regarding republish

### DIFF
--- a/src/managing-the-applications-lifecycle/deploy-applications/zones/zone-configure-app.md
+++ b/src/managing-the-applications-lifecycle/deploy-applications/zones/zone-configure-app.md
@@ -26,6 +26,4 @@ To configure an application to use a given deployment zone do the following:
 
 1. Click the **Save** button.
 
-1. If the new deployment zone uses a **container-based hosting technology**, you need to republish your application for the configuration changes to take effect.
-
-    On the other hand, if the selected deployment zone uses the **Classic Virtual Machines** hosting technology, the application is automatically deployed to the front-end servers included in the deployment zone. The application is also removed from all front-end servers that don't belong to the deployment zone.
+1. You need to republish your application for the configuration changes to take effect.

--- a/src/managing-the-applications-lifecycle/deploy-applications/zones/zone-configure-app.md
+++ b/src/managing-the-applications-lifecycle/deploy-applications/zones/zone-configure-app.md
@@ -26,4 +26,4 @@ To configure an application to use a given deployment zone do the following:
 
 1. Click the **Save** button.
 
-1. You need to republish your application for the configuration changes to take effect.
+1. Republish your application for the configuration changes to take effect.


### PR DESCRIPTION
The application needs always to be republish for the setting to become effective. This is true for all the types of deployment zones.
Also removed the Container's reference since the technology was in tech preview and is being removed from O11