### PR TITLE
Additional republishing and required info

### DIFF
--- a/src/managing-the-applications-lifecycle/secure-the-applications/apply-content-security-policy.md
+++ b/src/managing-the-applications-lifecycle/secure-the-applications/apply-content-security-policy.md
@@ -22,13 +22,14 @@ If you have LifeTime installed, set Content Security Policy using this managemen
 
 ### For all environments
 
-To configure the CSP in all environments use LifeTime, the management console of your infrastructure.
+To configure the CSP in all environments in LifeTime:
 
-1. Go to the **Infrastructure** section to see all environments.
+1. In LifeTime, go to the **Infrastructure** section to see all environments.
 1. In an environment, select the **Environment Security** option.
 1. Enable CSP.
 1. Configure directives, with one value per line.
-1. After saving, republish all applications using an ["All Components" solution].(https://success.outsystems.com/Support/Enterprise_Customers/Maintenance_and_Operations/Creating_and_using_an_%22All_Components%22_solution)
+1. Click **Save**.
+1. Republish all applications using an ["All Components" solution](https://success.outsystems.com/Support/Enterprise_Customers/Maintenance_and_Operations/Creating_and_using_an_%22All_Components%22_solution).
 
 ### For an app
 
@@ -39,7 +40,8 @@ To configure CSP for an application in LifeTime:
 1. In the drop list, select the environment to which the settings will apply.
 1. Enable CSP.
 1. Configure directives, with one value per line.
-1. After saving, republish the application on Service Center.
+1. Click **Save**.
+1. Republish the application in Service Center.
 
 <div class="warning" markdown="1">
 
@@ -91,7 +93,7 @@ When configuring CSP take into account the following risks of misconfiguration:
 
 ## Directives reference
 
-The list of available directives to configure Content Security Policy in OutSystems is described in the table below. Note that the required values on the right column are always applied to the CSP directives for the applications to work correctly and cannot be removed.
+The table below describes the list of available directives to configure Content Security Policy in OutSystems. The **Required values** column indicates the values that LifeTime automatically applies to the directive for the applications to work correctly. Those values cannot be removed.
 
 | Directive     | Reason        | Required values  |
 | :------------ |:--------------|:----------------|

--- a/src/managing-the-applications-lifecycle/secure-the-applications/apply-content-security-policy.md
+++ b/src/managing-the-applications-lifecycle/secure-the-applications/apply-content-security-policy.md
@@ -28,6 +28,7 @@ To configure the CSP in all environments use LifeTime, the management console of
 1. In an environment, select the **Environment Security** option.
 1. Enable CSP.
 1. Configure directives, with one value per line.
+1. After saving, republish all applications using an ["All Components" solution].(https://success.outsystems.com/Support/Enterprise_Customers/Maintenance_and_Operations/Creating_and_using_an_%22All_Components%22_solution)
 
 ### For an app
 
@@ -38,6 +39,7 @@ To configure CSP for an application in LifeTime:
 1. In the drop list, select the environment to which the settings will apply.
 1. Enable CSP.
 1. Configure directives, with one value per line.
+1. After saving, republish the application on Service Center.
 
 <div class="warning" markdown="1">
 
@@ -89,9 +91,9 @@ When configuring CSP take into account the following risks of misconfiguration:
 
 ## Directives reference
 
-The list of available directives to configure Content Security Policy in OutSystems is described in the table below.
+The list of available directives to configure Content Security Policy in OutSystems is described in the table below. Note that the required values on the right column are always applied to the CSP directives for the applications to work correctly and cannot be removed.
 
-| Directive     | Reason        | Default values  |
+| Directive     | Reason        | Required values  |
 | :------------ |:--------------|:----------------|
 | Base-uri      |The domains which can be used as base URL for applications screens.<br/>The following source expressions are allowed: `self`.|`self`|
 | Child-src     |The domains which applications are allowed to embed framed.<br/>The following source expressions are allowed: `self` and `*`.|`self`<br/>`gap:`|


### PR DESCRIPTION
Added some common pitfalls by customers, like:
- You need to republish apps/the environment if you change CSP;
- The default CSP values are actually required values to make the apps work correctly, and they cannot be edited or removed.