### PR TITLE
Improve the Session Token explanation

### DIFF
--- a/src/managing-the-applications-lifecycle/secure-the-applications/encrypt-viewstate.md
+++ b/src/managing-the-applications-lifecycle/secure-the-applications/encrypt-viewstate.md
@@ -24,17 +24,24 @@ The view state is a hidden field in the HTML of the web page. Its value property
 
 Check the [Microsoft documentation](https://docs.microsoft.com/en-us/dotnet/api/system.web.ui.control.viewstate?view=netframework-4.8) for more information about the view state.
 
-## Encrypting the view state using Factory Configuration
+## Toggling view state encryption using Factory Configuration
 
-Because a page's view state can contain sensitive information (such as the inputs a user added on a form) it's a good practice to encrypt the view state.
-It’s possible to encrypt the view state using the supported Forge component [Factory Configuration](https://www.outsystems.com/forge/component-overview/25/factory-configuration):
+Because a page's view state can contain sensitive information (such as the inputs a user added on a form) the view state is by default encrypted.
+You can confirm the view state is encrypted using the supported Forge component [Factory Configuration](https://www.outsystems.com/forge/component-overview/25/factory-configuration). 
 
-1. Install Factory Configuration in the environment you wish to encrypt the view state.
+If it's encrypted, **Encrypt Viewstate** will be ticked. If it's not, follow these steps:
 
-1. Open it on the browser and login using your LifeTime/Service Center credentials.
+1. Open Factory Configuration on the browser and login using your LifeTime/Service Center credentials.
 
 1. Navigate to the **Platform Configurations** tab and make sure **Encrypt Viewstate** is ticked. 
-    1. For an extra level of protection, it's also possible to enable the **Use Session Token to Encrypt View State** option. This will include an extra session generated token in the encrypted view state. This token changes after a login to a different user, and ensures every requested page is only valid in the context of that same user session. There are multiple use cases that are broken by this extra protection, so make sure to read the consequences that are explained in the Factory Configuration contextual help of this option.
+
+1. For an extra level of protection, it's also possible to enable the **Use Session Token to Encrypt View State** option. This will include an extra session generated token in the encrypted view state. This token changes after a login to a different user, and ensures every requested page is only valid in the context of that same user session. 
+
+<div class="warning" markdown="1">
+
+There are multiple use cases that are broken by this extra protection. Make sure to read the consequences that are explained in the Factory Configuration contextual help of this option.
+
+</div>
 
     ![Factory Configuration](images/encrypt-viewstate-FC.png)
 

--- a/src/managing-the-applications-lifecycle/secure-the-applications/encrypt-viewstate.md
+++ b/src/managing-the-applications-lifecycle/secure-the-applications/encrypt-viewstate.md
@@ -37,12 +37,12 @@ If it's encrypted, **Encrypt Viewstate** will be ticked. If it's not, follow the
 
 1. For an extra level of protection, it's also possible to enable the **Use Session Token to Encrypt View State** option. This will include an extra session generated token in the encrypted view state. This token changes after a login to a different user, and ensures every requested page is only valid in the context of that same user session. 
 
-<div class="warning" markdown="1">
+    <div class="warning" markdown="1">
 
-There are multiple use cases that are broken by this extra protection. Make sure to read the consequences that are explained in the Factory Configuration contextual help of this option.
+    There are multiple use cases that are broken by this extra protection. Make sure to read the consequences that are explained in the Factory Configuration contextual help of this option.
 
-</div>
+    </div>
 
     ![Factory Configuration](images/encrypt-viewstate-FC.png)
 
-1. [Apply the settings](https://success.outsystems.com/Support/Enterprise_Customers/Maintenance_and_Operations/Applying_Configurations_in_Service_Center#Apply_Pending_Settings_to_a_Set_of_Modules) to all modules.
+1. [Apply the settings](../deploy-applications/apply-configurations.md#apply-pending-settings-to-a-set-of-modules) to all modules.

--- a/src/managing-the-applications-lifecycle/secure-the-applications/encrypt-viewstate.md
+++ b/src/managing-the-applications-lifecycle/secure-the-applications/encrypt-viewstate.md
@@ -33,7 +33,8 @@ It’s possible to encrypt the view state using the supported Forge component [F
 
 1. Open it on the browser and login using your LifeTime/Service Center credentials.
 
-1. Navigate to the **Platform Configurations** tab and make sure **Encrypt Viewstate** is ticked. For an extra level of protection, the option **Use Session Token to Encrypt View State** will include the value of the session cookie **osVisitor** in the encrypted view state. This ensures that, in each user session, every requested page is only valid in the context of that same user session.
+1. Navigate to the **Platform Configurations** tab and make sure **Encrypt Viewstate** is ticked. 
+    1. For an extra level of protection, it's also possible to enable the **Use Session Token to Encrypt View State** option. This will include an extra session generated token in the encrypted view state. This token changes after a login to a different user, and ensures every requested page is only valid in the context of that same user session. There are multiple use cases that are broken by this extra protection, so make sure to read the consequences that are explained in the Factory Configuration contextual help of this option.
 
     ![Factory Configuration](images/encrypt-viewstate-FC.png)
 


### PR DESCRIPTION
The main goal was to remove the part saying the extra setting was related to the Visitor cookie, which was not correct.

But also separated the bullets and added a bit of a disclaimer, since the recommendation is for customer to have the Encrypt Viewstate enabled and the "Session Token" not enabled, as it breaks valid use cases like "multiple tab" scenarios.