### PR TITLE
Update light-process.md

### DIFF
--- a/src/develop/processes/light-process.md
+++ b/src/develop/processes/light-process.md
@@ -20,6 +20,7 @@ To enable light process execution, a process must meet all the following conditi
 * The process flow includes only one **Automatic Activity**, having a simple **Start** > **Automatic Activity** > **End** flow.
 
 * The **Launch On** property of the process is set with a database event.
+    * Only entities with the "Expose Process Events" enabled are allowed to be chosen
 
 * The **Expose Process Entity** property of the process is set to **No**.
 
@@ -56,4 +57,4 @@ To enable light process execution for a process, do the following:
     ![](images/light-process-3.png)
 
 After these steps and after publishing your module, the process is enabled for light process execution.  
-Keep in mind that only a trigger by a database event executes the process as a light process. Launching the process using the **Launch Process** action executes the process as a regular process.
+Keep in mind that only the creation of an entity record (the event configured in the "Launch On" of the process) triggers the process to execute as a light process. Launching the process using the Launch Process action executes the process as a regular process.


### PR DESCRIPTION
Make more clear that not every Database event can trigger a Light Process. Only the Creation of records. Also add detail about entity options to enable when we want to use an entity as a trigger for a Light Process.