### PR TITLE
Update DB System Requirements to be consistent with checklist

### DIFF
--- a/src/setup-maintain/setup/system-requirements.md
+++ b/src/setup-maintain/setup/system-requirements.md
@@ -47,7 +47,7 @@ Future revisions of OutSystems may require the installation of an update within 
 
 Keep in mind that you must use the same flavor of database engine for the 3 databases used by the platform (platform and apps, logs, session). Combinations of database engines, for example, using SQL Server for the platform database and Azure SQL database for the logs and or session databases (or any other combination), are not supported.
 
-* Microsoft SQL Server 2019 and compatibility level 150, since Platform Server 11.12.0 <sup>1</sup>
+* Microsoft SQL Server 2019 or higher, with compatibility level 150, since Platform Server 11.12.0 <sup>1</sup>
 * Microsoft SQL Server 2017 (Web Edition or higher edition)<sup>1</sup>
 * Microsoft SQL Server 2016 (Web Edition or higher edition)<sup>1</sup>
 * Microsoft SQL Server 2014 (Web Edition or higher edition)<sup>1</sup>


### PR DESCRIPTION
In the checklist only the Compatibility Level is mentioned, instead of the specific SQL Server version for 2019+
![image](https://github.com/OutSystems/docs-product/assets/5313340/f6df5f46-4275-42ae-9f1c-5db16dee73a8)

And while the idea was to be able to say that we support newer versions if as long as they have the correct compatibility level set.
But on the requirements it was an "**and**" , which gives the wrong idea.

I kept the text saying "Microsoft SQL Server 2019" as well just so it's not confusing for anyone that does not know exactly what are  "Compatibility Levels", but it's not really an issue since it's not possible to have "Compatibility Level 150" on older versions.