### PR TITLE
Update intro.md

### DIFF
--- a/src/develop/ui/accessibility/intro.md
+++ b/src/develop/ui/accessibility/intro.md
@@ -232,3 +232,5 @@ Use the [Popup widget](../../ui/inputs/popup.md) to create accessible modal dial
 
 * `role="dialog"`
 * `aria-modal="true"`
+
+Additionally, add the class `"has-accessible-features"` in the Style Classes of the Popup Widget to enable the accessibility features mentioned before in this document.

--- a/src/develop/ui/accessibility/intro.md
+++ b/src/develop/ui/accessibility/intro.md
@@ -233,4 +233,4 @@ Use the [Popup widget](../../ui/inputs/popup.md) to create accessible modal dial
 * `role="dialog"`
 * `aria-modal="true"`
 
-Additionally, the class `"has-accessible-features"` needs to be added manually in the Style Classes of the Popup Widget to enable the accessibility features mentioned before in this document.
+Additionally, the class `"has-accessible-features"` needs to be added manually in the Style Classes of the Popup Widget to enable the accessibility features.

--- a/src/develop/ui/accessibility/intro.md
+++ b/src/develop/ui/accessibility/intro.md
@@ -233,4 +233,4 @@ Use the [Popup widget](../../ui/inputs/popup.md) to create accessible modal dial
 * `role="dialog"`
 * `aria-modal="true"`
 
-Additionally, add the class `"has-accessible-features"` in the Style Classes of the Popup Widget to enable the accessibility features mentioned before in this document.
+Additionally, the class `"has-accessible-features"` needs to be added manually in the Style Classes of the Popup Widget to enable the accessibility features mentioned before in this document.


### PR DESCRIPTION
The instructions to enable accessibility tools did not affect popup widgets. To circumvent this limitation, we edited the document to recommend customers to manually add a class to the popup.