### PR TITLE
Update external-idp-lifetime.md

### DIFF
--- a/src/managing-the-applications-lifecycle/manage-it-teams/external-idp/external-idp-lifetime.md
+++ b/src/managing-the-applications-lifecycle/manage-it-teams/external-idp/external-idp-lifetime.md
@@ -34,7 +34,7 @@ To configure the external provider (OIDC) in LifeTime, follow these steps:
 
         You can validate the URL using the **Test configuration** link.
        
-    1. **Scopes**: Clicking the **Test** button after you enter the well-known configuration URL fetches all the scopes supported and enabled in the identity provider. The scopes are displayed on the **Configuration details** section. Any required scope for the user authentication process can be added and saved for the configuration.
+    1. **Scopes** (only applicable for LifeTime version 11.17.4 or higher): Clicking the **Test** button after you enter the well-known configuration URL fetches all the scopes supported and enabled in the identity provider. The scopes are displayed on the **Configuration details** section. Any required scope for the user authentication process can be added and saved for the configuration.
   
           
        **Note:** Please follow these guidelines when selecting values for scopes:


### PR DESCRIPTION
The Configuration details section is only available in LifeTime version 11.17.4 when setting scopes was introduced as a new feature. I have checked all versions from 11.17.0 to 11.17.4 to confirm this. A customer has already asked why they could not see any scopes when using the 'Test configuration' link.