### PR TITLE
Update method description to show breaking change information

### DIFF
--- a/src/ref/apis/auto/lifetime-deployment-api-v2.final.md
+++ b/src/ref/apis/auto/lifetime-deployment-api-v2.final.md
@@ -2445,6 +2445,7 @@ Go to
 <div class="panel-body">
 <section class="sw-operation-description">
 <p>Updates a given deployment. An optional list of applications to include in the deployment can be specified. The input is a subset of deployment object.</p>
+<p><b>Breaking change: </b>Using this method to remove an application from a plan sets the application as "Do Nothing" while keeping it as part of the plan. From LifeTime v11.22.0 onwards, removing an application from a plan will set it as "Do Nothing" and will no longer appear in the plan.</p>
 </section>
 <section class="sw-request-body">
 <p><span class="label label-default">application/json</span> 


### PR DESCRIPTION
The method was changed to hide removed applications from the deployment plan, instead of appearing as "Do Nothing" in the plan's application list.