### PR TITLE
Update about-permission-levels.md

### DIFF
--- a/src/manage-platform-app-lifecycle/manage-it-teams/about-permission-levels.md
+++ b/src/manage-platform-app-lifecycle/manage-it-teams/about-permission-levels.md
@@ -144,7 +144,7 @@ Assigned for an **Application** | Not applicable.
 
 Add System Dependencies | |
 ---------|----------
-Assigned as **Default Role** | In the applications for which the user has Change and Deploy permission, the user can add new dependencies to the public elements of System module.
+Assigned as **Default Role** | In the applications for which the user has Change and Deploy permission, the user can add new dependencies to the public elements of System module. Once these dependencies are added, any user, even without permission to add system dependencies, can use them.
 Assigned for a **Team** | Not applicable.
 Assigned for an **Application** | Not applicable.
 


### PR DESCRIPTION
The documentation was unclear that someone without Add System Dependencies permissions could use the dependencies after they are added to the modules. We aim to clarify that you need permission to add the dependencies, but after they are added anyone who can edit the module can use the added dependencies.