### PR TITLE
Update api-request-code.md

### DIFF
--- a/src/ref/apis/lifetime-deployment/examples/api-request-code.md
+++ b/src/ref/apis/lifetime-deployment/examples/api-request-code.md
@@ -40,7 +40,7 @@ Extension code is not available through the API.
 
 To download the source code of an app or a module, ensure that the environment from where you want to get the source code has:
 
-* Platform Server version 11.28.0 or higher
+* Platform Server version 11.28.0 or higher (for applications only, this feature is also available in Platform Server version 11.27.0)
 * LifeTime version 11.22.0 or higher
 * [LifeTime Service Account](https://success.outsystems.com/Documentation/11/Reference/OutSystems_APIs/LifeTime_API_v2/REST_API_Authentication)
     * Service Account needs Open and Debug on the environment


### PR DESCRIPTION
For the application's source code only, it's possible to use PS 11.27.0 (instead of PS 11.28.0). You may not want to add this note since we are setting a higher PS version that will already include 11.27 but this ensures that this article is consistent with https://success.outsystems.com/documentation/11/reference/outsystems_apis/lifetime_api_v2/.