### PR TITLE
[RPM-5340] - Clarify that some of the listed classes only apply to Reactive Web apps

### DIFF
--- a/src/building-apps/ui/look-feel/responsive.md
+++ b/src/building-apps/ui/look-feel/responsive.md
@@ -30,9 +30,9 @@ The CSS classes add the following:
 
 * **Device:** .desktop, .tablet, .phone, .iphonex
 * **Orientation:** .landscape, .portrait
-* **Browser:** .chrome, .firefox, .edge, .safari, etc.
+* **Browser:** .chrome, .firefox, .edge, .safari, etc. (only applies to Reactive Web apps)
 * **Operation system:** .windows, .osx, .ios, .android, etc.
-* **Touch devices detection:** .is--touch
+* **Touch devices detection:** .is--touch (only applies to Reactive Web apps)
 
 **Example:**
 


### PR DESCRIPTION
Currently, the classes that refer to Browser and Touch Detection are only applied to Reactive Web apps. We have created RPM-5340 to see if this is the intended behaviour or not. In the meantime, this documentation should be updated to avoid misleading customers.  If this is the desired behaviour, then the changes in the documentation should be permanent.