### PR TITLE
Fixed Unary Minus Table

### DIFF
--- a/src/ref/logic/expressions/operators.md
+++ b/src/ref/logic/expressions/operators.md
@@ -31,9 +31,9 @@ Yields the negation of its numeric operand.
 
 The following are the data types allowed for the unary minus (\-) operator:
 
-Operator | Text | Long Integer | Integer | Decimal | Boolean | Date Time | Date | Time  
----|---|---|---|---|---|---|---|---  
-| \- (Unary minus) | No | Yes | Yes | Yes | No | No | No | No  
+| Text | Long Integer | Integer | Decimal | Boolean | Date Time | Date | Time  
+|---|---|---|---|---|---|---|---| 
+| No | Yes | Yes | Yes | No | No | No | No  |
   
 ### Arithmetic operators /, \-, \*
 

--- a/src/ref/logic/expressions/operators.md
+++ b/src/ref/logic/expressions/operators.md
@@ -31,9 +31,9 @@ Yields the negation of its numeric operand.
 
 The following are the data types allowed for the unary minus (\-) operator:
 
-\- (Unary minus) | Text | Long Integer | Integer | Decimal | Boolean | Date Time | Date | Time  
+Operator | Text | Long Integer | Integer | Decimal | Boolean | Date Time | Date | Time  
 ---|---|---|---|---|---|---|---|---  
- | No | Yes | Yes | Yes | No | No | No | No  
+| \- (Unary minus) | No | Yes | Yes | Yes | No | No | No | No  
   
 ### Arithmetic operators /, \-, \*
 


### PR DESCRIPTION
Currently, the (Unary minus) table is misaligned:
![image](https://github.com/user-attachments/assets/2587b6cb-5d92-404c-9e68-fb88b5525fd8)

This pull request fixes the table's alignment.