### PR TITLE
Update intro.md

### DIFF
--- a/src/integration-with-systems/mobile-plugins/cordova-plugin/intro.md
+++ b/src/integration-with-systems/mobile-plugins/cordova-plugin/intro.md
@@ -48,7 +48,7 @@ Wrap a Cordova plugin through the **Extensibility Configuration** module propert
 * the Cordova identifier (the value of the `identifier` key)
 * the ZIP file from the **Resources** folder in the **Data** tab (the value of the `resource` key)
 
-Unless it’s a [plugin supported by OutSystems](intro.md) and you're using a public repository to reference the plugin, it's recommended that you fork the plugin repository or use a tagged version, such as `https://example.com/sampleplugin/sampleplugin.git#1.1.0`. This prevents breaking changes in the plugin and the applications using the plugin. Additionally, if tags aren't used, two different builds may produce different results. This is important when deploying across one or more environments, where testing in one environment may be invalidated by a different build generated for another environment. 
+Unless it’s a [plugin supported by OutSystems](intro.md) and you're using a public repository to reference the plugin, it's recommended that you fork the plugin repository or use a tagged version, such as `https://example.com/sampleplugin/sampleplugin.git#v1.1.0`. This prevents breaking changes in the plugin and the applications using the plugin. Additionally, if tags aren't used, two different builds may produce different results. This is important when deploying across one or more environments, where testing in one environment may be invalidated by a different build generated for another environment. 
 
 You can use JSON for configuring additional settings required by the plugin. For detailed information about the description of the JSON, refer to [Extensibility Configurations JSON Schema](../../../deploying-apps/mobile-app-packaging-delivery/compliance-with-third-party-licenses.md).
 


### PR DESCRIPTION
Changes the example URL for tagged version, adding a "v" before the version number. Not using the "v" may result in Outsystems not able to download the repo.